### PR TITLE
fix Kushki object visibility

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <resourceExtensions />
     <wildcardResourcePatterns>
       <entry name="!?*.java" />
       <entry name="!?*.form" />
@@ -11,12 +10,6 @@
       <entry name="!?*.flex" />
       <entry name="!?*.kt" />
       <entry name="!?*.clj" />
-      <entry name="!?*.aj" />
     </wildcardResourcePatterns>
-    <annotationProcessing>
-      <profile default="true" name="Default" enabled="false">
-        <processorPath useClasspath="true" />
-      </profile>
-    </annotationProcessing>
   </component>
 </project>

--- a/kushki-android/src/main/java/com/kushkipagos/android/Kushki.kt
+++ b/kushki-android/src/main/java/com/kushkipagos/android/Kushki.kt
@@ -1,6 +1,6 @@
 package com.kushkipagos.android
 
-class Kushki internal constructor(private val publicMerchantId: String, currency: String,
+class Kushki public constructor(private val publicMerchantId: String, currency: String,
                                   environment: Environment) {
     private val kushkiClient: KushkiClient
     private val kushkiJsonBuilder: KushkiJsonBuilder


### PR DESCRIPTION
Change Kushki class visibility modifier.

You can't use Kushki Object from another module with `internal` class modifier, so I changed it to public.